### PR TITLE
move `getPercentile` method to main bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The `window.__tvi_sampler` object exposes the following methods:
 | Method | Parameters |
 | ---    | ---        |
 | `checkInSample(callback)` | `callback` - function with boolean parameter indicating if device is in or out of sample |
+| `getPercentile(callback)` | `callback` - function with numeric parameter returning the current percentile |
 
 ## Testing module
 
@@ -49,7 +50,6 @@ Adding the testing module enhances the `window.__tvi_sampler` api with the follo
 
 | Method | Parameters |
 | ---    | ---        |
-| `getPercentile(callback)` | `callback`- function with numeric parameter returning the current percentile |
 | `setPercentile(percentile, callback)` | `percentile` - numeric value between 1 and 100<br />`callback`- function with numeric parameter returning the new percentile |
 | `isTechCookieValid(callback)`| `callback` - called with boolean parameter indicating if tech cookie is valid |
 | `setValidTechCookie(callback)` | `callback` - called when the tech-cookie was set. After reloading the application, sampling takes place |

--- a/src/sampler-iframe.html
+++ b/src/sampler-iframe.html
@@ -36,6 +36,11 @@ __ejs(/* } */);
               window._sendMessage("cb$" + id + ";" + JSON.stringify({ param: cbParam }));
             });
             break;
+          case "getPercentile":
+            window.__tvi_sampler.getPercentile(function (cbParam) {
+              window._sendMessage("cb$" + id + ";" + JSON.stringify({ param: cbParam }));
+            });
+            break;
           default:
             break;
         }
@@ -50,7 +55,6 @@ __ejs(/* } */);
     samplerScriptTag.setAttribute("type", "text/javascript");
     samplerScriptTag.setAttribute("src", window.location.protocol + "//__ejs(/*-SAMPLER_HOST*/);/__ejs(/*-IMPL_FILE*/);");
     document.getElementsByTagName("head")[0].appendChild(samplerScriptTag);
-
     //]]>
   </script>
 </head>

--- a/src/sampler-impl.js
+++ b/src/sampler-impl.js
@@ -15,7 +15,7 @@
     if (now - parseInt("__ejs(/*-TECHNICAL_COOKIE_MIN_AGE*/);") > technicalCookie) {
       percentile = parseInt(readStorage(namePercentileCookie));
       if (!percentile) {
-        var percentile = Math.floor(Math.random() * 100) + 1;
+        percentile = Math.floor(Math.random() * 100) + 1;
         writeStorage(namePercentileCookie, percentile);
       }
     }
@@ -28,6 +28,13 @@
     var desiredPercentile = parseInt("__ejs(/*-IN_SAMPLE_PERCENTILE*/);");
     if (callback && typeof callback === "function") {
       callback(!!percentile && percentile <= desiredPercentile);
+    }
+  };
+
+  sampler.getPercentile = function (callback) {
+    var percentile = parseInt(readStorage(namePercentileCookie)) || null;
+    if (callback && typeof callback === "function") {
+      callback(percentile);
     }
   };
 })();

--- a/src/sampler.js
+++ b/src/sampler.js
@@ -52,6 +52,10 @@
     sampler._q[sampler._q.length] = { m: "checkInSample", a: Array.prototype.slice.call(arguments) };
   };
 
+  sampler.getPercentile = function () {
+    sampler._q[sampler._q.length] = { m: "getPercentile", a: Array.prototype.slice.call(arguments) };
+  };
+
   function callQueue() {
     for (var i = 0; i < sampler._q.length; i++) {
       var f = sampler._q[i];
@@ -138,6 +142,10 @@
 
       sampler.checkInSample = function (callback) {
         iframeMessage("checkInSample", undefined, callback);
+      };
+
+      sampler.getPercentile = function (callback) {
+        iframeMessage("getPercentile", undefined, callback);
       };
 
       onSamplerLoaded();

--- a/src/testing-iframe.html
+++ b/src/testing-iframe.html
@@ -31,11 +31,6 @@ __ejs(/* } */);
         var param = JSON.parse(message[3]);
 
         switch (method) {
-          case "getPercentile":
-            window.__tvi_sampler.getPercentile(function (cbParam) {
-              window._sendMessage("cb$" + id + ";" + JSON.stringify({ param: cbParam }));
-            });
-            break;
           case "setPercentile":
             window.__tvi_sampler.setPercentile(param.param, function (cbParam) {
               window._sendMessage("cb$" + id + ";" + JSON.stringify({ param: cbParam }));

--- a/src/testing-impl.js
+++ b/src/testing-impl.js
@@ -7,13 +7,6 @@
   sampler = window.__tvi_sampler || {};
   window.__tvi_sampler = sampler;
 
-  sampler.getPercentile = function (callback) {
-    var percentile = parseInt(readStorage(namePercentileCookie)) || null;
-    if (callback && typeof callback === "function") {
-      callback(percentile);
-    }
-  };
-
   sampler.setPercentile = function (percentile, callback) {
     writeStorage(namePercentileCookie, percentile);
     if (callback && typeof callback === "function") {

--- a/src/testing.js
+++ b/src/testing.js
@@ -3,10 +3,6 @@
   window.__tvi_sampler = sampler;
   sampler._tq = [];
 
-  sampler.getPercentile = function () {
-    sampler._tq[sampler._tq.length] = { m: "getPercentile", a: Array.prototype.slice.call(arguments) };
-  };
-
   sampler.setPercentile = function () {
     sampler._tq[sampler._tq.length] = { m: "setPercentile", a: Array.prototype.slice.call(arguments) };
   };
@@ -70,10 +66,6 @@
         iframe.parentElement.removeChild(iframe);
         return waitForDOMElement("head", loadTesting, 3);
       }
-
-      sampler.getPercentile = function (callback) {
-        iframeMessage("getPercentile", undefined, callback);
-      };
 
       sampler.setPercentile = function (percentile, callback) {
         iframeMessage("setPercentile", percentile, callback);

--- a/test/index.html
+++ b/test/index.html
@@ -26,6 +26,9 @@
         console.warn("too bad, you are not part of the game :-(");
       }
     });
+    window.__tvi_sampler.getPercentile(function (percentile) {
+      console.info("your percentile is", percentile);
+    });
     //]]>
   </script>
 </body>


### PR DESCRIPTION
In order to being able to implement https://tvinsight.atlassian.net/browse/TVI-2433, we need to make the `getPercentile` api method available not from the optional testing bundle, but from the main bundle.