### PR TITLE
Config for `checkInSample` behaviour during TC evaluation

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -38,21 +38,24 @@ jobs:
                 "IN_SAMPLE_PERCENTILE": 10,
                 "TECHNICAL_COOKIE_MIN_AGE": 172800000,
                 "TECHNICAL_COOKIE_NAME": "x-sampler-t",
-                "PERCENTILE_COOKIE_NAME": "x-sampler-p"
+                "PERCENTILE_COOKIE_NAME": "x-sampler-p",
+                "IN_SAMPLE_WITHOUT_TC": false
               },
               "de-ip": {
                 "SAMPLER_HOST": "sampling.tvping.com",
                 "IN_SAMPLE_PERCENTILE": 10,
                 "TECHNICAL_COOKIE_MIN_AGE": 172800000,
                 "TECHNICAL_COOKIE_NAME": "x-sampler-t",
-                "PERCENTILE_COOKIE_NAME": "x-sampler-p"
+                "PERCENTILE_COOKIE_NAME": "x-sampler-p",
+                "IN_SAMPLE_WITHOUT_TC": false
               },
               "de-p7s1": {
                 "SAMPLER_HOST": "sampling.tvping.com",
                 "IN_SAMPLE_PERCENTILE": 100,
                 "TECHNICAL_COOKIE_MIN_AGE": 172800000,
                 "TECHNICAL_COOKIE_NAME": "x-sampler-t",
-                "PERCENTILE_COOKIE_NAME": "x-sampler-p"
+                "PERCENTILE_COOKIE_NAME": "x-sampler-p",
+                "IN_SAMPLE_WITHOUT_TC": true
               }
             }
 

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -37,21 +37,24 @@ jobs:
                 "IN_SAMPLE_PERCENTILE": 10,
                 "TECHNICAL_COOKIE_MIN_AGE": 172800000,
                 "TECHNICAL_COOKIE_NAME": "x-sampler-t",
-                "PERCENTILE_COOKIE_NAME": "x-sampler-p"
+                "PERCENTILE_COOKIE_NAME": "x-sampler-p",
+                "IN_SAMPLE_WITHOUT_TC": false
               },
               "de-ip": {
                 "SAMPLER_HOST": "sampling.tvping.com",
                 "IN_SAMPLE_PERCENTILE": 10,
                 "TECHNICAL_COOKIE_MIN_AGE": 172800000,
                 "TECHNICAL_COOKIE_NAME": "x-sampler-t",
-                "PERCENTILE_COOKIE_NAME": "x-sampler-p"
+                "PERCENTILE_COOKIE_NAME": "x-sampler-p",
+                "IN_SAMPLE_WITHOUT_TC": false
               },
               "de-p7s1": {
                 "SAMPLER_HOST": "sampling.tvping.com",
                 "IN_SAMPLE_PERCENTILE": 100,
                 "TECHNICAL_COOKIE_MIN_AGE": 172800000,
                 "TECHNICAL_COOKIE_NAME": "x-sampler-t",
-                "PERCENTILE_COOKIE_NAME": "x-sampler-p"
+                "PERCENTILE_COOKIE_NAME": "x-sampler-p",
+                "IN_SAMPLE_WITHOUT_TC": true
               }
             }
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The tracking sampler can be used to only select devices within a specified perce
 > As described in the [Build](#build) section, multiple entry points for the sample can be built/deployed, so `sampler-default.js` can also be e.g. `sampler-twenty.js`
 
 > [!IMPORTANT]
-> While the tech cookie[^1] is not yet validated, the `checkInSample` method will always return `true`. To check if it returned `true` because the tech cookie evaluation is not done yet, you can use `getPercentile`, which will return `undefined` in this case.
+> While the tech cookie[^1] is not yet validated, the `checkInSample` returns `true` or `false` based on the `IN_SAMPLE_WITHOUT_TC` config value (see [Build](#build) section). To check if the tech cookie evaluation is not done yet, you can use `getPercentile`, which will return `undefined` in this case.
 
 ### API methods
 
@@ -113,22 +113,37 @@ The build process requires a `build.json` file with the following structure:
     "IN_SAMPLE_PERCENTILE": 10,
     "TECHNICAL_COOKIE_MIN_AGE": 172800000,
     "TECHNICAL_COOKIE_NAME": "x-sampler-t",
-    "PERCENTILE_COOKIE_NAME": "x-sampler-p"
+    "PERCENTILE_COOKIE_NAME": "x-sampler-p",
+    "IN_SAMPLE_WITHOUT_TC": false
   },
   "twenty": {
     "SAMPLER_HOST": "sampling.tvping.com",
     "IN_SAMPLE_PERCENTILE": 20,
     "TECHNICAL_COOKIE_MIN_AGE": 172800000,
     "TECHNICAL_COOKIE_NAME": "x-sampler-t",
-    "PERCENTILE_COOKIE_NAME": "x-sampler-p"
+    "PERCENTILE_COOKIE_NAME": "x-sampler-p",
+    "IN_SAMPLE_WITHOUT_TC": true
   },
 }
 ```
+> [!CAUTION]
+> All [config values](#config-values) are mandatory!
+
 > [!IMPORTANT]
-> `TECHNICAL_COOKIE_MIN_AGE` is in milliseconds
+> `TECHNICAL_COOKIE_MIN_AGE` is in milliseconds.
 
 As shown in the example above, multiple build configs can be added. The example above would build two entrypoints, `sampler-default.js` (the key of the build config is added as a filename suffix) and `sampler-twenty.js`. If the key would be an empty string, no file suffix will be added.
 
 Every config also gets it's own testing module, following the same rules (e.g. above config outputs `testing-default.js` and `testing-twenty.js` to be used with the respective entrypoints).
+
+### Config values
+| Value | Description |
+| ---   | ---         |
+| `SAMPLER_HOST` | Host where sampler is deployed to |
+| `IN_SAMPLE_PERCENTILE` | Which percentile the device needs to be in |
+| `TECHNICAL_COOKIE_MIN_AGE` | How long the technical cookie needs to be stored until the sampler gets active|
+| `TECHNICAL_COOKIE_NAME` | Cookie name / localStorage key where technical cookie is saved |
+| `PERCENTILE_COOKIE_NAME` | Cookie name / localStorage key where device percentile is saved |
+| `IN_SAMPLE_WITHOUT_TC` | Should `checkInSample` return `true` or `false` while technical cookie evaluation is not finished |
 
 [^1]: The tech cookie is a cookie/localStorage key which stores the timestamp at creation. If this cookie/localStorage can still be read after at least 2 days, it is assumed that the device can store data in cookies/localStorage and therefore the percentile of the device can be persisted. If cookies/localStorage are not available, the device will always be out-of-sample.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,11 @@ The tracking sampler can be used to only select devices within a specified perce
 </script>
 ```
 
+> [!NOTE]
 > As described in the [Build](#build) section, multiple entry points for the sample can be built/deployed, so `sampler-default.js` can also be e.g. `sampler-twenty.js`
+
+> [!IMPORTANT]
+> While the tech cookie[^1] is not yet validated, the `checkInSample` method will always return `true`. To check if it returned `true` because the tech cookie evaluation is not done yet, you can use `getPercentile`, which will return `undefined` in this case.
 
 ### API methods
 
@@ -26,7 +30,7 @@ The `window.__tvi_sampler` object exposes the following methods:
 | Method | Parameters |
 | ---    | ---        |
 | `checkInSample(callback)` | `callback` - function with boolean parameter indicating if device is in or out of sample |
-| `getPercentile(callback)` | `callback` - function with numeric parameter returning the current percentile |
+| `getPercentile(callback)` | `callback` - function with numeric parameter returning the current percentile (`undefined` if not yet set) |
 
 ## Testing module
 
@@ -40,6 +44,7 @@ To enable the testing module, the following script tag has to be added:
 <script type="text/javascript" src="http://sampling.tvping.com/testing-default.js"></script>
 ```
 
+> [!NOTE]
 > As described in the [Build](#build) section, if a different entrypoint like e.g. `sampler-twenty.js` is used, also the corresponding testing module needs to be used. I the case of `sampler-twenty.js` this would be `testing-twenty.js`.
 
 It is important that the script tag is added **after** the script tag loading the sampler!
@@ -119,7 +124,7 @@ The build process requires a `build.json` file with the following structure:
   },
 }
 ```
-
+> [!IMPORTANT]
 > `TECHNICAL_COOKIE_MIN_AGE` is in milliseconds
 
 As shown in the example above, multiple build configs can be added. The example above would build two entrypoints, `sampler-default.js` (the key of the build config is added as a filename suffix) and `sampler-twenty.js`. If the key would be an empty string, no file suffix will be added.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To enable the testing module, the following script tag has to be added:
 ```
 
 > [!NOTE]
-> As described in the [Build](#build) section, if a different entrypoint like e.g. `sampler-twenty.js` is used, also the corresponding testing module needs to be used. I the case of `sampler-twenty.js` this would be `testing-twenty.js`.
+> As described in the [Build](#build) section, if a different entrypoint like e.g. `sampler-twenty.js` is used, also the corresponding testing module needs to be used. In the case of `sampler-twenty.js` this would be `testing-twenty.js`.
 
 It is important that the script tag is added **after** the script tag loading the sampler!
 

--- a/app.ts
+++ b/app.ts
@@ -24,7 +24,7 @@ app.get("*", function(req, res) {
     TECHNICAL_COOKIE_MIN_AGE: 1000 * 60 * 60 * 24 * 2,
     TECHNICAL_COOKIE_NAME: "x-sampler-t",
     PERCENTILE_COOKIE_NAME: "x-sampler-p",
-    IN_SAMPLE_WITHOUT_TC: false,
+    IN_SAMPLE_WITHOUT_TC: true,
     __CONFIG_NAME: null,
   });
 });

--- a/app.ts
+++ b/app.ts
@@ -24,6 +24,7 @@ app.get("*", function(req, res) {
     TECHNICAL_COOKIE_MIN_AGE: 1000 * 60 * 60 * 24 * 2,
     TECHNICAL_COOKIE_NAME: "x-sampler-t",
     PERCENTILE_COOKIE_NAME: "x-sampler-p",
+    IN_SAMPLE_WITHOUT_TC: false,
     __CONFIG_NAME: null,
   });
 });

--- a/src/sampler-impl.js
+++ b/src/sampler-impl.js
@@ -5,20 +5,19 @@
   __ejs(/*- include("partials/storage.js") */);
 
   var technicalCookie = parseInt(readStorage(nameTechnicalCookie));
-  var percentile = 0;
 
   var now = Date.now();
   if (!technicalCookie) {
     writeStorage(nameTechnicalCookie, now);
     technicalCookie = now;
-  } else {
-    if (now - parseInt("__ejs(/*-TECHNICAL_COOKIE_MIN_AGE*/);") > technicalCookie) {
-      percentile = parseInt(readStorage(namePercentileCookie));
-      if (!percentile) {
-        percentile = Math.floor(Math.random() * 100) + 1;
-        writeStorage(namePercentileCookie, percentile);
-      }
-    }
+  }
+
+  var technicalCookiePassed = now - parseInt("__ejs(/*-TECHNICAL_COOKIE_MIN_AGE*/);") > technicalCookie;
+
+  var percentile = parseInt(readStorage(namePercentileCookie)) || 0;
+  if (!percentile && technicalCookiePassed) {
+    percentile = Math.floor(Math.random() * 100) + 1;
+    writeStorage(namePercentileCookie, percentile);
   }
 
   sampler = window.__tvi_sampler || {};
@@ -27,12 +26,11 @@
   sampler.checkInSample = function (callback) {
     var desiredPercentile = parseInt("__ejs(/*-IN_SAMPLE_PERCENTILE*/);");
     if (callback && typeof callback === "function") {
-      callback(!!percentile && percentile <= desiredPercentile);
+      callback(!technicalCookiePassed || (!!percentile && percentile <= desiredPercentile));
     }
   };
 
   sampler.getPercentile = function (callback) {
-    var percentile = parseInt(readStorage(namePercentileCookie)) || null;
     if (callback && typeof callback === "function") {
       callback(percentile);
     }

--- a/src/sampler-impl.js
+++ b/src/sampler-impl.js
@@ -27,11 +27,9 @@
   sampler.checkInSample = function (callback) {
     var desiredPercentile = parseInt("__ejs(/*-IN_SAMPLE_PERCENTILE*/);");
     if (callback && typeof callback === "function") {
-      var inSample = false;
+      var inSample = inSampleWithoutTC;
       if (technicalCookiePassed) {
         inSample = !!percentile && percentile <= desiredPercentile;
-      } else {
-        inSample = inSampleWithoutTC;
       }
       callback(inSample);
     }

--- a/src/sampler-impl.js
+++ b/src/sampler-impl.js
@@ -14,7 +14,7 @@
 
   var technicalCookiePassed = now - parseInt("__ejs(/*-TECHNICAL_COOKIE_MIN_AGE*/);") > technicalCookie;
 
-  var percentile = parseInt(readStorage(namePercentileCookie)) || 0;
+  var percentile = parseInt(readStorage(namePercentileCookie)) || undefined;
   if (!percentile && technicalCookiePassed) {
     percentile = Math.floor(Math.random() * 100) + 1;
     writeStorage(namePercentileCookie, percentile);

--- a/src/sampler-impl.js
+++ b/src/sampler-impl.js
@@ -1,6 +1,7 @@
 (function () {
   var nameTechnicalCookie = "__ejs(/*-TECHNICAL_COOKIE_NAME*/);";
   var namePercentileCookie = "__ejs(/*-PERCENTILE_COOKIE_NAME*/);";
+  var inSampleWithoutTC = __ejs(/*-IN_SAMPLE_WITHOUT_TC*/);
 
   __ejs(/*- include("partials/storage.js") */);
 
@@ -26,7 +27,13 @@
   sampler.checkInSample = function (callback) {
     var desiredPercentile = parseInt("__ejs(/*-IN_SAMPLE_PERCENTILE*/);");
     if (callback && typeof callback === "function") {
-      callback(!technicalCookiePassed || (!!percentile && percentile <= desiredPercentile));
+      var inSample = false;
+      if (technicalCookiePassed) {
+        inSample = !!percentile && percentile <= desiredPercentile;
+      } else {
+        inSample = inSampleWithoutTC;
+      }
+      callback(inSample);
     }
   };
 

--- a/test/index.html
+++ b/test/index.html
@@ -21,14 +21,17 @@
     //<![CDATA[
     window.__tvi_sampler.checkInSample(function (inSample) {
       window.__tvi_sampler.getPercentile(function (percentile) {
-        if (inSample) {
-          if (!percentile) {
-            console.warn("percentile not yet assigned", percentile);
-          } else {
-            console.info("percentile in desired range", percentile);
+        if (!percentile) {
+          console.warn("percentile not yet assigned", percentile);
+          if (inSample) {
+            console.info("in sample while TC evaluation not done");
           }
         } else {
-          console.error("percentile not in desired range", percentile);
+          if (inSample) {
+            console.info("percentile in desired range", percentile);
+          } else {
+            console.error("percentile not in desired range", percentile);
+          }
         }
       });
     });

--- a/test/index.html
+++ b/test/index.html
@@ -23,7 +23,7 @@
       window.__tvi_sampler.getPercentile(function (percentile) {
         if (inSample) {
           if (!percentile) {
-            console.warn("percentile not yet assigned");
+            console.warn("percentile not yet assigned", percentile);
           } else {
             console.info("percentile in desired range", percentile);
           }

--- a/test/index.html
+++ b/test/index.html
@@ -20,14 +20,17 @@
   <script type="text/javascript">
     //<![CDATA[
     window.__tvi_sampler.checkInSample(function (inSample) {
-      if (inSample) {
-        console.info("lucky you, you are amongst the chosen ones :-)");
-      } else {
-        console.warn("too bad, you are not part of the game :-(");
-      }
-    });
-    window.__tvi_sampler.getPercentile(function (percentile) {
-      console.info("your percentile is", percentile);
+      window.__tvi_sampler.getPercentile(function (percentile) {
+        if (inSample) {
+          if (!percentile) {
+            console.warn("percentile not yet assigned");
+          } else {
+            console.info("percentile in desired range", percentile);
+          }
+        } else {
+          console.error("percentile not in desired range", percentile);
+        }
+      });
     });
     //]]>
   </script>

--- a/test/sampler.spec.js
+++ b/test/sampler.spec.js
@@ -21,7 +21,7 @@ describe.each(cases)("Tracking Sampler - iFrame: %s", (iFrame) => {
   }, 5000);
 
   describe("before tech cookie becomes valid", () => {
-    it("should be out of sample", async () => {
+    it("should always be in sample", async () => {
       const techCookieValid = await page.evaluate(() => {
         return new Promise((resolve) => {
           window.__tvi_sampler.isTechCookieValid(resolve);
@@ -32,9 +32,15 @@ describe.each(cases)("Tracking Sampler - iFrame: %s", (iFrame) => {
           window.__tvi_sampler.checkInSample(resolve);
         });
       });
+      const percentile = await page.evaluate(() => {
+        return new Promise((resolve) => {
+          window.__tvi_sampler.getPercentile(resolve);
+        });
+      });
 
       expect(techCookieValid).toBe(false);
-      expect(inSample).toBe(false);
+      expect(inSample).toBe(true);
+      expect(percentile).toBe(0);
     });
   });
 

--- a/test/sampler.spec.js
+++ b/test/sampler.spec.js
@@ -40,7 +40,7 @@ describe.each(cases)("Tracking Sampler - iFrame: %s", (iFrame) => {
 
       expect(techCookieValid).toBe(false);
       expect(inSample).toBe(true);
-      expect(percentile).toBe(0);
+      expect(percentile).toBe(undefined);
     });
   });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,11 +22,9 @@
     "esm": true,
   },
   "include": [
-    "src/**/*"
+    "app.ts"
   ],
   "exclude": [
-    "node_modules",
-    "**/*.spec.ts",
-    "**/*.test.ts"
+    "node_modules"
   ]
 }


### PR DESCRIPTION
### Description
In order to ensure that a percentile can be saved on the device, the sampler tries to set a technical cookie on first load. Only if this cookie can be read after a defined amount of time (currently 2 days), the actual percentile value is saved on the device.

During this evaluation period, the `checkInSample` method would always return `false`, which could lead to undesired behaviour (e.g. P7DE case: sampler is integrated into an already running tracking, it would disable the tracking for two days).

This PR adds a build config key `IN_SAMPLE_WITHOUT_TC`, which defines what `checkInSample` should return if the technical cookie evaluation is not yet finished.

To check if  the technical cookie evaluation is not finished yet, the `getPercentile` method can be used, as during this period the returned percentile will  be `undefined`.

### Target Release
v1.2.0

### Jira Link
https://tvinsight.atlassian.net/browse/TVI-2480