### PR TITLE
remove usage of Date.now()

### DIFF
--- a/src/sampler-impl.js
+++ b/src/sampler-impl.js
@@ -7,7 +7,7 @@
 
   var technicalCookie = parseInt(readStorage(nameTechnicalCookie));
 
-  var now = Date.now();
+  var now = new Date().getTime();
   if (!technicalCookie) {
     writeStorage(nameTechnicalCookie, now);
     technicalCookie = now;

--- a/src/testing-impl.js
+++ b/src/testing-impl.js
@@ -17,12 +17,12 @@
   sampler.isTechCookieValid = function (callback) {
     var technicalCookie = parseInt(readStorage(nameTechnicalCookie)) || null;
     if (callback && typeof callback === 'function') {
-      callback(!!technicalCookie && Date.now() - parseInt('__ejs(/*-TECHNICAL_COOKIE_MIN_AGE*/);') > technicalCookie);
+      callback(!!technicalCookie && new Date().getTime() - parseInt('__ejs(/*-TECHNICAL_COOKIE_MIN_AGE*/);') > technicalCookie);
     }
   };
 
   sampler.setValidTechCookie = function (callback) {
-    writeStorage(nameTechnicalCookie, Date.now() - parseInt('__ejs(/*-TECHNICAL_COOKIE_MIN_AGE*/);') * 2);
+    writeStorage(nameTechnicalCookie, new Date().getTime() - parseInt('__ejs(/*-TECHNICAL_COOKIE_MIN_AGE*/);') * 2);
     if (callback && typeof callback === 'function') {
       callback();
     }


### PR DESCRIPTION
### Description
`Date.now()` is not defined in [OIPF Release 1 DAE Reference Guide](https://oipf.tv/docs/OIPF-T2-R1_DAE_Reference_Guide_v1_0-2010-03-11.pdf). Therefore we need to use `new Date().getTime()`.

### Target release
v1.3.0